### PR TITLE
Add context provider

### DIFF
--- a/src/app/context/MyContext.js
+++ b/src/app/context/MyContext.js
@@ -1,0 +1,37 @@
+import React, { createContext, useState } from "react";
+
+export const MyContext = createContext(null);
+
+export const MyProvider = ({ children }) => {
+  const [isButtonClicked, setIsButtonClicked] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [isReserveClicked, setIsReserveClicked] = useState(false);
+
+  const handleButtonClick = () => setIsButtonClicked(true);
+  const handleCancel = () => setIsButtonClicked(false);
+  const handleReserve = () => {
+    setIsReserveClicked(true);
+    setIsButtonClicked(false);
+  };
+
+  const handleLoading = () => {
+    setLoading(true);
+    setTimeout(() => setLoading(false), 1000);
+  };
+
+  return (
+    <MyContext.Provider
+      value={{
+        isButtonClicked,
+        handleButtonClick,
+        handleCancel,
+        handleReserve,
+        loading,
+        handleLoading,
+        isReserveClicked,
+      }}
+    >
+      {children}
+    </MyContext.Provider>
+  );
+};

--- a/src/app/pages/App/App.jsx
+++ b/src/app/pages/App/App.jsx
@@ -2,7 +2,7 @@ import Home from "./Home";
 import Vehicles from "./Vehicles";
 import About from "./About";
 import Contact from "./Contact";
-import { MyProvider } from "../context/MyContext";
+import { MyProvider } from "../../context/MyContext";
 import { Route, Routes } from "react-router-dom";
 import { StyledEngineProvider } from "@mui/material/styles";
 import AOS from "aos";

--- a/src/app/pages/App/Home/Book.jsx
+++ b/src/app/pages/App/Home/Book.jsx
@@ -1,6 +1,6 @@
 import { useState, useContext, useEffect } from "react";
 import axios from "axios";
-import { MyContext } from "../../../../Client/src/context/MyContext";
+import { MyContext } from "../../../context/MyContext";
 
 const Book = () => {
   const [cars, setCars] = useState([]);

--- a/src/app/pages/App/Home/Products.jsx
+++ b/src/app/pages/App/Home/Products.jsx
@@ -4,7 +4,7 @@ import Suv from "./Suv";
 import Van from "./Van";
 import Truck from "./Track";
 import Reserve from "./Reserve";
-import { MyContext } from "../../../../Client/src/context/MyContext";
+import { MyContext } from "../../../context/MyContext";
 
 const Products = () => {
   const { isButtonClicked } = useContext(MyContext);

--- a/src/app/pages/App/Home/Reserve.jsx
+++ b/src/app/pages/App/Home/Reserve.jsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { useState, useEffect, useContext } from "react";
-import { MyContext } from "../../../../Client/src/context/MyContext";
+import { MyContext } from "../../../context/MyContext";
 
 const Reserve = (props) => {
   const [className, setClassName] = useState("");


### PR DESCRIPTION
## Summary
- implement `MyContext` provider in `src/app/context/MyContext.js`
- fix imports to use the new context location

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551644e0a88321b9efb29817f90e60